### PR TITLE
Update aiven cli version and bump default pg version

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Other optional environment config vars:
 
 ```bash
 AIVEN_CLOUD # (default: "do-nyc")
-AIVEN_PG_VERSION # (default: "pgversion=12")
+AIVEN_PG_VERSION # (default: "14")
 AIVEN_PLAN # (default: startup-4)
 AIVEN_SERVICE_TYPE # (default: "pg" for postgres)
 AIVEN_DBNAME # name of the db (default: "propertymeld")

--- a/bin/steps/heroku
+++ b/bin/steps/heroku
@@ -26,4 +26,4 @@ if [ -d "$ENV_DIR" ]; then
 fi
 
 puts_step "install aiven-client"
-python -m pip install aiven-client===2.3.5
+python -m pip install aiven-client===2.14.8

--- a/bin/tasks.py
+++ b/bin/tasks.py
@@ -94,8 +94,8 @@ service_config = {
     "service_type": os.environ.get("AIVEN_SERVICE_TYPE", "pg") or "pg",
     "plan": os.environ.get("AIVEN_PLAN", "startup-4")
     or "startup-4",  # hobbyist does not support pooling
-    "pg_version": os.environ.get("AIVEN_PG_VERSION", "pg_version=12")
-    or "pg_version=12",
+    "pg_version": os.environ.get("AIVEN_PG_VERSION", "14")
+    or "14",
 }
 
 stdout(f"service_config: {service_config}")


### PR DESCRIPTION
The Aiven CLI was pegged to an old version which did not support the tags command. Verified tags work now.
